### PR TITLE
plugins: remove syntastic HTML check

### DIFF
--- a/vim/plugin_config.vim
+++ b/vim/plugin_config.vim
@@ -79,5 +79,6 @@ nnoremap <Leader>g :Goyo<CR>
 " Syntastic
 """""""""""""""""""""""""""
 let g:syntastic_always_populate_loc_list = 1
+let g:syntastic_html_checkers = []
 nnoremap <Leader>{ :lprev<CR>
 nnoremap <Leader>} :lnext<CR>


### PR DESCRIPTION
Hello sir,

I fixed the html checking on your dotfiles repo.

While I was here, I noticed you use one-line-quote comment blocks. This is less efficient. I changed that too.

I also added an editorconfig file for 4-space tabs.

Thank you sir.
